### PR TITLE
Use ([return], error) paradigm with performGetRequest

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Implement status codes: https://golang.org/src/net/http/status.go
-func performGetRequest(url string) *http.Response {
+func performGetRequest(url string) (*http.Response, error) {
 
 	sleepTime := 0
 	retryCount := 0
@@ -19,7 +19,8 @@ func performGetRequest(url string) *http.Response {
 
 	for err != nil {
 		if retryCount >= 10 {
-			log.Fatal("Request was tried more than 10 times, giving up: " + url)
+			log.Error("Request was tried more than 10 times, giving up: " + url)
+			return nil, err
 		}
 		sleepTime = sleepTime + 1
 		retryCount = retryCount + 1
@@ -27,7 +28,7 @@ func performGetRequest(url string) *http.Response {
 		res, err = getRequest(url)
 	}
 
-	return res
+	return res, nil
 }
 
 // Performs an HTTP GET Method

--- a/syncer.go
+++ b/syncer.go
@@ -126,7 +126,11 @@ func (syncer Syncer) syncPackage(upstream BldrApi, target BldrApi, p PackageData
 				continue
 			}
 			log.Infof("Downloading package %s for target %s", pack.Name, pack.Target)
-			file := upstream.downloadPackage(pack)
+			file, err := upstream.downloadPackage(pack)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
 			files = append(files, file)
 		} else {
 			log.Info(fmt.Sprintf("Dependancy %s exists in target, skipping download", pkgName))
@@ -138,9 +142,15 @@ func (syncer Syncer) syncPackage(upstream BldrApi, target BldrApi, p PackageData
 		log.Error(err)
 		return
 	}
+
 	pkgName := fmt.Sprintf("%s/%s/%s/%s", p.Origin, p.Name, p.Version, p.Release)
 	log.Info(fmt.Sprintf("Downloading package %s for target %s", pack.Name, pack.Target))
-	file := upstream.downloadPackage(pack)
+	file, err := upstream.downloadPackage(pack)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
 	log.Infof("Uploading package %s to channel %s", pkgName, channel)
 	packageUpload(target, file, channel)
 


### PR DESCRIPTION
This is so that a failed performGetRequest will not cause the entire main process to exit (i.e. the caller of performGetRequest will handle the error, rather than performGetRequest calling log.Fatal). This means that if a package has a dependency whose fetching leads to a 404, the package will fail but the sync process will continue for the remainder of the packages.